### PR TITLE
#27 - Add code coverage support improve

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,7 +34,7 @@ jobs:
             scalaShort: "2.11"
             overall: 0.0
             changed: 80.0
-          - scala: 2.12.12
+          - scala: 2.12.17
             scalaShort: "2.12"
             overall: 0.0
             changed: 80.0

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,7 +29,15 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        scala: [2.11.12, 2.12.12]
+        include:
+          - scala: 2.11.12
+            scalaShort: "2.11"
+            overall: 0.0
+            changed: 80.0
+          - scala: 2.12.12
+            scalaShort: "2.12"
+            overall: 0.0
+            changed: 80.0
     name: Build on Scala ${{matrix.scala}}
     steps:
       - name: Checkout code
@@ -40,4 +48,27 @@ jobs:
         with:
           java-version: "adopt@1.8"
       - name: Build and run tests
-        run: sbt ++${{matrix.scala}} test
+        run: sbt ++${{matrix.scala}} jacoco
+      - name: Add coverage to PR
+        id: jacoco
+        uses: madrapps/jacoco-report@v1.3
+        with:
+          paths: >
+            ${{ github.workspace }}/core/target/scala-${{ matrix.scalaShort }}/jacoco/report/jacoco.xml,
+            ${{ github.workspace }}/examples/target/scala-${{ matrix.scalaShort }}/jacoco/report/jacoco.xml,
+            ${{ github.workspace }}/slick/target/scala-${{ matrix.scalaShort }}/jacoco/report/jacoco.xml
+          token: ${{ secrets.GITHUB_TOKEN }}
+          min-coverage-overall: ${{ matrix.overall }}
+          min-coverage-changed-files: ${{ matrix.changed }}
+          title: JaCoCo code coverage report - scala ${{ matrix.scala }}
+          update-comment: true
+      - name: Get the Coverage info
+        run: |
+          echo "Total coverage ${{ steps.jacoco.outputs.coverage-overall }}"
+          echo "Changed Files coverage ${{ steps.jacoco.outputs.coverage-changed-files }}"
+      - name: Fail PR if changed files coverage is less than ${{ matrix.changed }}%
+        if: ${{ steps.jacoco.outputs.coverage-changed-files < 80.0 }}
+        uses: actions/github-script@v6
+        with:
+          script: |
+            core.setFailed('Changed files coverage is less than ${{ matrix.changed }}%!')

--- a/build.sbt
+++ b/build.sbt
@@ -60,7 +60,7 @@ lazy val faDbCore = (project in file("core"))
     (Compile / compile) := ((Compile / compile) dependsOn printScalaVersion).value // printScalaVersion is run with compile
   )
   .settings(
-    jacocoReportSettings := commonJacocoReportSettings.withTitle("fa-db:core Jacoco Report"),
+    jacocoReportSettings := commonJacocoReportSettings.withTitle(s"fa-db:core Jacoco Report - scala:${scalaVersion.value}"),
     jacocoExcludes := commonJacocoExcludes
   )
 
@@ -71,7 +71,7 @@ lazy val faDBSlick = (project in file("slick"))
     (Compile / compile) := ((Compile / compile) dependsOn printScalaVersion).value // printScalaVersion is run with compile
   ).dependsOn(faDbCore)
   .settings(
-    jacocoReportSettings := commonJacocoReportSettings.withTitle("fa-db:slick Jacoco Report"),
+    jacocoReportSettings := commonJacocoReportSettings.withTitle(s"fa-db:slick Jacoco Report - scala:${scalaVersion.value}"),
     jacocoExcludes := commonJacocoExcludes
   )
 
@@ -84,7 +84,7 @@ lazy val faDBExamples = (project in file("examples"))
     publish / skip := true
   ).dependsOn(faDbCore, faDBSlick)
   .settings(
-    jacocoReportSettings := commonJacocoReportSettings.withTitle("fa-db:examples Jacoco Report"),
+    jacocoReportSettings := commonJacocoReportSettings.withTitle(s"fa-db:examples Jacoco Report - scala:${scalaVersion.value}"),
     jacocoExcludes := commonJacocoExcludes
   )
 

--- a/build.sbt
+++ b/build.sbt
@@ -17,7 +17,7 @@
 ThisBuild / organization := "za.co.absa.fa-db"
 
 lazy val scala211 = "2.11.12"
-lazy val scala212 = "2.12.12"
+lazy val scala212 = "2.12.17"
 
 ThisBuild / scalaVersion := scala211
 ThisBuild / crossScalaVersions := Seq(scala211, scala212)

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -17,4 +17,22 @@
 addSbtPlugin("de.heikoseeberger"  % "sbt-header"   % "5.6.0")
 addSbtPlugin("com.github.sbt"     % "sbt-release"  % "1.1.0")
 addSbtPlugin("com.github.sbt"     % "sbt-pgp"      % "2.1.2")
-addSbtPlugin("com.github.sbt"     % "sbt-jacoco"   % "3.4.0")
+
+// sbt-jacoco - workaround related dependencies required to download
+lazy val ow2Version = "9.5"
+lazy val jacocoVersion = "0.8.9-absa.1"
+
+def jacocoUrl(artifactName: String): String = s"https://github.com/AbsaOSS/jacoco/releases/download/$jacocoVersion/org.jacoco.$artifactName-$jacocoVersion.jar"
+def ow2Url(artifactName: String): String = s"https://repo1.maven.org/maven2/org/ow2/asm/$artifactName/$ow2Version/$artifactName-$ow2Version.jar"
+
+addSbtPlugin("com.jsuereth" %% "scala-arm" % "2.0" from "https://repo1.maven.org/maven2/com/jsuereth/scala-arm_2.11/2.0/scala-arm_2.11-2.0.jar")
+addSbtPlugin("com.jsuereth" %% "scala-arm" % "2.0" from "https://repo1.maven.org/maven2/com/jsuereth/scala-arm_2.12/2.0/scala-arm_2.12-2.0.jar")
+
+addSbtPlugin("za.co.absa.jacoco" % "report" % jacocoVersion from jacocoUrl("report"))
+addSbtPlugin("za.co.absa.jacoco" % "core" % jacocoVersion from jacocoUrl("core"))
+addSbtPlugin("za.co.absa.jacoco" % "agent" % jacocoVersion from jacocoUrl("agent"))
+addSbtPlugin("org.ow2.asm" % "asm" % ow2Version from ow2Url("asm"))
+addSbtPlugin("org.ow2.asm" % "asm-commons" % ow2Version from ow2Url("asm-commons"))
+addSbtPlugin("org.ow2.asm" % "asm-tree" % ow2Version from ow2Url("asm-tree"))
+
+addSbtPlugin("za.co.absa.sbt" % "sbt-jacoco" % "3.4.1-absa.1" from "https://github.com/AbsaOSS/sbt-jacoco/releases/download/3.4.1-absa.1/sbt-jacoco-3.4.1-absa.1.jar")


### PR DESCRIPTION
- Used Absa fork of JaCoCo solution - with scala method filtering.
- Added support for code coverage GitHub action check as part of PR.

Closes #27 