### PR TITLE
Rename GH jobs to solve chaos.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,8 +14,6 @@
 # limitations under the License.
 #
 
-name: Build
-
 on:
   push:
     branches: [master ]
@@ -37,7 +35,7 @@ jobs:
             scalaShort: "2.12"
             overall: 0.0
             changed: 80.0
-    name: JaCoco test coverage on Scala ${{matrix.scala}}
+    name: Build
     steps:
       - name: Checkout code
         uses: actions/checkout@v2


### PR DESCRIPTION
Fix confusing names of GH job names.