### PR TITLE
#37: Remove global execution context usage

### DIFF
--- a/core/src/main/scala/za/co/absa/fadb/DBEngine.scala
+++ b/core/src/main/scala/za/co/absa/fadb/DBEngine.scala
@@ -16,8 +16,7 @@
 
 package za.co.absa.fadb
 
-import scala.concurrent.ExecutionContext.Implicits.global
-import scala.concurrent.Future
+import scala.concurrent.{ExecutionContext, Future}
 import scala.language.higherKinds
 
 /**
@@ -30,6 +29,8 @@ trait DBEngine {
     * @tparam T - the return type of the query
     */
   type QueryType[T] <: Query[T]
+
+  implicit val executor: ExecutionContext
 
   /**
     * The actual query executioner of the queries of the engine

--- a/core/src/test/scala/za/co/absa/fadb/DBFunctionSuite.scala
+++ b/core/src/test/scala/za/co/absa/fadb/DBFunctionSuite.scala
@@ -18,9 +18,8 @@ package za.co.absa.fadb
 
 import org.scalatest.funsuite.AnyFunSuite
 
-import scala.concurrent.Future
+import scala.concurrent.{ExecutionContext, Future}
 import za.co.absa.fadb.naming_conventions.SnakeCaseNaming.Implicits.namingConvention
-
 
 class DBFunctionSuite extends AnyFunSuite {
 
@@ -30,6 +29,8 @@ class DBFunctionSuite extends AnyFunSuite {
 
   private implicit object EngineThrow extends DBEngine {
     override def run[R](query: QueryType[R]): Future[Seq[R]] = neverHappens
+
+    override implicit val executor: ExecutionContext = ExecutionContext.Implicits.global
   }
 
   private object FooNamed extends DBSchema(EngineThrow)

--- a/core/src/test/scala/za/co/absa/fadb/DBSchemaSuite.scala
+++ b/core/src/test/scala/za/co/absa/fadb/DBSchemaSuite.scala
@@ -18,7 +18,7 @@ package za.co.absa.fadb
 import org.scalatest.funsuite.AnyFunSuite
 import za.co.absa.fadb.naming_conventions.SnakeCaseNaming.Implicits.namingConvention
 
-import scala.concurrent.{Await, Future}
+import scala.concurrent.{Await, ExecutionContext, Future}
 
 class DBSchemaSuite extends AnyFunSuite {
 
@@ -26,6 +26,8 @@ class DBSchemaSuite extends AnyFunSuite {
     override def run[R](query: QueryType[R]): Future[Seq[R]] = {
       throw new Exception("Should never get here")
     }
+
+    override implicit val executor: ExecutionContext = ExecutionContext.Implicits.global
   }
 
   test("schema name default") {

--- a/examples/src/test/scala/za/co/absa/fadb/examples/enceladus/DatasetSchemaSuite.scala
+++ b/examples/src/test/scala/za/co/absa/fadb/examples/enceladus/DatasetSchemaSuite.scala
@@ -25,6 +25,7 @@ import za.co.absa.fadb.statushandling.StatusException
 
 import scala.concurrent.Await
 import scala.concurrent.duration.Duration
+import scala.concurrent.ExecutionContext.Implicits.global
 
 class DatasetSchemaSuite extends AnyWordSpec with Matchers {
   private val db = Database.forConfig("menasdb")

--- a/slick/src/main/scala/za/co/absa/fadb/slick/SlickPgEngine.scala
+++ b/slick/src/main/scala/za/co/absa/fadb/slick/SlickPgEngine.scala
@@ -19,7 +19,7 @@ package za.co.absa.fadb.slick
 
 import za.co.absa.fadb.DBEngine
 
-import scala.concurrent.Future
+import scala.concurrent.{ExecutionContext, Future}
 import slick.jdbc.PostgresProfile.api._
 
 import scala.language.higherKinds
@@ -28,7 +28,7 @@ import scala.language.higherKinds
   * [[DBEngine]] based on the Slick library in the Postgres flavor
   * @param db - the Slick database
   */
-class SlickPgEngine(val db: Database) extends DBEngine {
+class SlickPgEngine(val db: Database)(implicit val executor: ExecutionContext) extends DBEngine {
 
   /**
     * The type of Queries for Slick


### PR DESCRIPTION
Removes hard-coded `import scala.concurrent.ExecutionContext.Implicits.global` usage. Execution context is now an implicit of `DBEngine`.

Slick uses its own execution context(s) tough.  

Closes #37 