### PR TITLE
#99: DBEngine requirement removed from DBSchema. Fixes #99.

### DIFF
--- a/core/src/main/scala/za/co/absa/fadb/DBSchema.scala
+++ b/core/src/main/scala/za/co/absa/fadb/DBSchema.scala
@@ -19,60 +19,45 @@ package za.co.absa.fadb
 import za.co.absa.fadb.naming.NamingConvention
 
 /**
-  * An abstract class, an ancestor to represent a database schema (each database function should be placed in a schema)
+  * An abstract class, an ancestor to represent a database schema
   * The database name of the schema is derived from the class name based on the provided naming convention
   * @param schemaNameOverride - in case the class name would not match the database schema name, this gives the
-  *                           possibility of override
-  * @param dBEngine           - [[DBEngine]] to execute the functions with. Not directly needed for the DBSchema class, rather
-  *                           to be passed on to [[DBFunction]] members of the schema
-  * @param namingConvention   - the [[za.co.absa.fadb.naming.NamingConvention NamingConvention]] prescribing how to convert a class name into a db object name
+  * @param namingConvention   - the [[za.co.absa.fadb.naming.NamingConvention NamingConvention]]
+ *                           prescribing how to convert a class name into a db object name
   */
-abstract class DBSchema(schemaNameOverride: Option[String] = None)
-                       (implicit dBEngine: DBEngine, implicit val namingConvention: NamingConvention) {
+abstract class DBSchema(schemaNameOverride: Option[String] = None)(implicit val namingConvention: NamingConvention)
+{
 
-  def this(schemaNameOverride: String)
-          (implicit dBEngine: DBEngine, namingConvention: NamingConvention) {
-    this(Option(schemaNameOverride))(dBEngine, namingConvention)
+  def this(schemaNameOverride: String)(implicit namingConvention: NamingConvention) {
+    this(Option(schemaNameOverride))(namingConvention)
   }
 
-  def this(dBEngine: DBEngine, schemaNameOverride: String)
-          (implicit namingConvention: NamingConvention) {
-    this(Option(schemaNameOverride))(dBEngine, namingConvention)
+  def this()(implicit namingConvention: NamingConvention) {
+    this(None)(namingConvention)
   }
 
-  def this(dBEngine: DBEngine)
-          (implicit namingConvention: NamingConvention) {
-    this(None)(dBEngine, namingConvention)
-  }
-
-  def this(namingConvention: NamingConvention, schemaNameOverride:String)
-          (implicit dBEngine: DBEngine) {
-    this(Option(schemaNameOverride))(dBEngine, namingConvention)
-  }
-
-  def this(namingConvention: NamingConvention)
-          (implicit dBEngine: DBEngine) {
-    this(None)(dBEngine, namingConvention)
+  def this(namingConvention: NamingConvention, schemaNameOverride: String) {
+    this(Option(schemaNameOverride))(namingConvention)
   }
 
   /**
-    * To easy pass over to [[DBFunction]] members of the schema
-    */
+   * To easy pass over to [[DBFunction]] members of the schema
+   */
   protected implicit val schema: DBSchema = this
 
   /**
-    * Function to convert a class to the associated DB object name, based on the class' name. For transformation from the
-    * class name to usual db name the schema's [[za.co.absa.fadb.naming.NamingConvention NamingConvention]] is used.
-    * @param c  - class which name to use to get the DB object name
-    * @return   - the db object name
-    */
+   * Function to convert a class to the associated DB object name, based on the class' name. For transformation from the
+   * class name to usual db name the schema's [[za.co.absa.fadb.naming.NamingConvention NamingConvention]] is used.
+   * @param c  - class which name to use to get the DB object name
+   * @return   - the db object name
+   */
   def objectNameFromClassName(c: Class[_]): String = {
     namingConvention.fromClassNamePerConvention(c)
   }
 
   /**
-    * Name of the schema. Based on the schema's class name or provided override
-    */
+   * Name of the schema. Based on the schema's class name or provided override
+   */
   val schemaName: String = schemaNameOverride.getOrElse(objectNameFromClassName(getClass))
 
 }

--- a/core/src/test/scala/za/co/absa/fadb/DBFunctionSuite.scala
+++ b/core/src/test/scala/za/co/absa/fadb/DBFunctionSuite.scala
@@ -33,8 +33,8 @@ class DBFunctionSuite extends AnyFunSuite {
     override implicit val executor: ExecutionContext = ExecutionContext.Implicits.global
   }
 
-  private object FooNamed extends DBSchema(EngineThrow)
-  private object FooNameless extends DBSchema(EngineThrow, "")
+  private object FooNamed extends DBSchema
+  private object FooNameless extends DBSchema("")
 
   test("Function name check"){
     case class MyFunction(override val schema: DBSchema) extends DBFunction[Unit, Unit, DBEngine](schema) {

--- a/core/src/test/scala/za/co/absa/fadb/DBSchemaSuite.scala
+++ b/core/src/test/scala/za/co/absa/fadb/DBSchemaSuite.scala
@@ -18,27 +18,17 @@ package za.co.absa.fadb
 import org.scalatest.funsuite.AnyFunSuite
 import za.co.absa.fadb.naming.implementations.SnakeCaseNaming.Implicits.namingConvention
 
-import scala.concurrent.{ExecutionContext, Future}
-
 class DBSchemaSuite extends AnyFunSuite {
 
-  private object EngineThrow extends DBEngine {
-    override def run[R](query: QueryType[R]): Future[Seq[R]] = {
-      throw new Exception("Should never get here")
-    }
-
-    override implicit val executor: ExecutionContext = ExecutionContext.Implicits.global
-  }
-
   test("schema name default") {
-    class Foo extends DBSchema(EngineThrow)
+    class Foo extends DBSchema
 
     val schema = new Foo
     assert(schema.schemaName == "foo")
   }
 
   test("schema name overridden") {
-    class Foo extends DBSchema(EngineThrow, "bar")
+    class Foo extends DBSchema("bar")
 
     val schema = new Foo
     assert(schema.schemaName == "bar")

--- a/core/src/test/scala/za/co/absa/fadb/DBSchemaSuite.scala
+++ b/core/src/test/scala/za/co/absa/fadb/DBSchemaSuite.scala
@@ -16,6 +16,7 @@
 package za.co.absa.fadb
 
 import org.scalatest.funsuite.AnyFunSuite
+import za.co.absa.fadb.naming.NamingConvention
 import za.co.absa.fadb.naming.implementations.SnakeCaseNaming.Implicits.namingConvention
 
 class DBSchemaSuite extends AnyFunSuite {
@@ -31,6 +32,26 @@ class DBSchemaSuite extends AnyFunSuite {
     class Foo extends DBSchema("bar")
 
     val schema = new Foo
+    assert(schema.schemaName == "bar")
+  }
+
+  test("schema name with naming convention without override") {
+    object LowerCaseNamingConvention extends NamingConvention {
+      def stringPerConvention(original: String): String = original.toLowerCase
+    }
+    class Bar extends DBSchema(LowerCaseNamingConvention, null)
+
+    val schema = new Bar
+    assert(schema.schemaName == "bar") // Assuming the naming convention converts "Bar" to "bar"
+  }
+
+  test("schema name with naming convention with override") {
+    object LowerCaseNamingConvention extends NamingConvention {
+      def stringPerConvention(original: String): String = original.toLowerCase
+    }
+    class Bar extends DBSchema(LowerCaseNamingConvention, "bar")
+
+    val schema = new Bar
     assert(schema.schemaName == "bar")
   }
 


### PR DESCRIPTION
DBEngine requirement was removed from the DBSchema class.