### PR TITLE
streaming functions for doobie and slick with tests

### DIFF
--- a/core/src/main/scala/za/co/absa/fadb/DBStreamingEngine.scala
+++ b/core/src/main/scala/za/co/absa/fadb/DBStreamingEngine.scala
@@ -1,0 +1,9 @@
+package za.co.absa.fadb
+
+abstract class DBStreamingEngine[F[_]] {
+
+  type QueryType[R] <: Query[R]
+
+  def runStreaming[R](query: QueryType[R]): fs2.Stream[F, R]
+
+}

--- a/doobie/src/it/scala/za/co/absa/fadb/doobiedb/DoobieStreamingResultFunctionTest.scala
+++ b/doobie/src/it/scala/za/co/absa/fadb/doobiedb/DoobieStreamingResultFunctionTest.scala
@@ -1,0 +1,29 @@
+package za.co.absa.fadb.doobiedb
+
+import cats.effect.IO
+import cats.effect.unsafe.implicits.global
+import doobie.implicits.toSqlInterpolator
+import doobie.util.Read
+import doobie.util.fragment.Fragment
+import org.scalatest.funsuite.AnyFunSuite
+import za.co.absa.fadb.DBSchema
+import za.co.absa.fadb.doobiedb.DoobieFunction.DoobieStreamingResultFunction
+
+class DoobieStreamingResultFunctionTest extends AnyFunSuite with DoobieTest {
+
+  class GetActors(implicit schema: DBSchema, dbEngine: DoobieStreamingEngine[IO])
+    extends DoobieStreamingResultFunction[GetActorsQueryParameters, Actor, IO] {
+
+    override def sql(values: GetActorsQueryParameters)(implicit read: Read[Actor]): Fragment =
+      sql"SELECT actor_id, first_name, last_name FROM ${Fragment.const(functionName)}(${values.firstName}, ${values.lastName})"
+  }
+
+  private val getActors = new GetActors()(Runs, new DoobieStreamingEngine(transactor))
+
+  test("Retrieving actor from database") {
+    val expectedResultElem = Actor(49, "Pavel", "Marek")
+    val results = getActors(GetActorsQueryParameters(Some("Pavel"), Some("Marek"))).take(10).compile.toList.unsafeRunSync()
+    assert(results.contains(expectedResultElem))
+  }
+
+}

--- a/doobie/src/main/scala/za/co/absa/fadb/doobiedb/DoobieFunction.scala
+++ b/doobie/src/main/scala/za/co/absa/fadb/doobiedb/DoobieFunction.scala
@@ -138,6 +138,13 @@ object DoobieFunction {
   ) extends DBMultipleResultFunction[I, R, DoobieEngine[F], F](functionNameOverride)
       with DoobieFunction[I, R]
 
+  abstract class DoobieStreamingResultFunction[I, R, F[_]: Async](functionNameOverride: Option[String] = None)(
+    implicit override val schema: DBSchema,
+    val dbEngine: DoobieStreamingEngine[F],
+    val readR: Read[R]
+  ) extends DBStreamingResultFunction[I, R, DoobieStreamingEngine[F], F](functionNameOverride)
+      with DoobieFunction[I, R]
+
   /**
    *  `DoobieOptionalResultFunction` is an abstract class that extends `DBOptionalResultFunction` with `DoobiePgEngine` as the engine type.
    *  It represents a database function that returns an optional result.

--- a/doobie/src/main/scala/za/co/absa/fadb/doobiedb/DoobieStreamingEngine.scala
+++ b/doobie/src/main/scala/za/co/absa/fadb/doobiedb/DoobieStreamingEngine.scala
@@ -1,0 +1,20 @@
+package za.co.absa.fadb.doobiedb
+
+import cats.effect.Async
+import doobie.Transactor
+import doobie.implicits.toDoobieStreamOps
+import doobie.util.Read
+import za.co.absa.fadb.DBStreamingEngine
+
+class DoobieStreamingEngine[F[_]: Async](val transactor: Transactor[F], chunkSize: Int = 512) extends DBStreamingEngine[F] {
+
+  type QueryType[R] = DoobieQuery[R]
+
+  override def runStreaming[R](query: QueryType[R]): fs2.Stream[F, R] =
+    executeStreamingQuery(query)(query.readR)
+
+  private def executeStreamingQuery[R](query: QueryType[R])(implicit readR: Read[R]): fs2.Stream[F, R] = {
+    query.fragment.query[R].streamWithChunkSize(chunkSize).transact(transactor)
+  }
+
+}

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -21,6 +21,7 @@ object Dependencies {
   private def commonDependencies(scalaVersion: String): Seq[ModuleID] = Seq(
     "org.typelevel" %% "cats-core" % "2.9.0",
     "org.typelevel" %% "cats-effect" % "3.5.0",
+    "co.fs2" %% "fs2-core" % "3.7.0",
     "org.scalatest"      %% "scalatest" % "3.1.0"           % "test,it",
     "org.scalatest"      %% "scalatest-flatspec" % "3.2.0"  % "test,it",
     "org.scalatestplus"  %% "mockito-1-10" % "3.1.0.0"      % "test,it"
@@ -39,7 +40,8 @@ object Dependencies {
       "org.slf4j"            % "slf4j-nop"                    % "1.7.26",
       "com.typesafe.slick"  %% "slick-hikaricp"               % "3.3.3",
       "org.postgresql"       % "postgresql"                   % "42.6.0",
-      "com.github.tminglei" %% "slick-pg"                     % "0.20.4"   % Optional
+      "com.github.tminglei" %% "slick-pg"                     % "0.20.4"   % Optional,
+      "co.fs2" %% "fs2-reactive-streams" % "3.9.3"
     )
   }
 

--- a/slick/src/it/scala/za/co/absa/fadb/slick/SlickStreamingResultFunctionTest.scala
+++ b/slick/src/it/scala/za/co/absa/fadb/slick/SlickStreamingResultFunctionTest.scala
@@ -1,0 +1,32 @@
+package za.co.absa.fadb.slick
+
+import cats.effect.IO
+import cats.effect.unsafe.implicits.global
+import org.scalatest.funsuite.AnyFunSuite
+import slick.jdbc.SQLActionBuilder
+import za.co.absa.fadb.DBSchema
+import za.co.absa.fadb.slick.SlickFunction.SlickStreamingResultFunction
+import za.co.absa.fadb.slick.FaDbPostgresProfile.api._
+
+class SlickStreamingResultFunctionTest extends AnyFunSuite with SlickTest {
+
+  class GetActors(implicit override val schema: DBSchema, val dbEngine: SlickPgStreamingEngine[IO])
+    extends SlickStreamingResultFunction[GetActorsQueryParameters, Actor, IO]
+      with ActorSlickConverter {
+
+    override def fieldsToSelect: Seq[String] = super.fieldsToSelect ++ Seq("actor_id", "first_name", "last_name")
+
+    override protected def sql(values: GetActorsQueryParameters): SQLActionBuilder = {
+      sql"""SELECT #$selectEntry FROM #$functionName(${values.firstName},${values.lastName}) #$alias;"""
+    }
+  }
+
+  private val getActors = new GetActors()(Runs, new SlickPgStreamingEngine[IO](db))
+
+  test("Retrieving actors from database") {
+    val expectedResultElem = Actor(49, "Pavel", "Marek")
+    val results = getActors(GetActorsQueryParameters(Some("Pavel"), Some("Marek"))).take(10).compile.toList.unsafeRunSync()
+    assert(results.contains(expectedResultElem))
+  }
+
+}

--- a/slick/src/main/scala/za/co/absa/fadb/slick/SlickFunction.scala
+++ b/slick/src/main/scala/za/co/absa/fadb/slick/SlickFunction.scala
@@ -16,8 +16,9 @@
 
 package za.co.absa.fadb.slick
 
+import cats.effect.kernel.Async
 import slick.jdbc.{GetResult, SQLActionBuilder}
-import za.co.absa.fadb.DBFunction.{DBMultipleResultFunction, DBOptionalResultFunction, DBSingleResultFunction}
+import za.co.absa.fadb.DBFunction.{DBMultipleResultFunction, DBOptionalResultFunction, DBSingleResultFunction, DBStreamingResultFunction}
 import za.co.absa.fadb.exceptions.StatusException
 import za.co.absa.fadb.{DBFunctionWithStatus, DBSchema, FunctionStatusWithData}
 
@@ -100,6 +101,12 @@ object SlickFunction {
     override val schema: DBSchema,
     dBEngine: SlickPgEngine
   ) extends DBMultipleResultFunction[I, R, SlickPgEngine, Future](functionNameOverride)
+      with SlickFunction[I, R]
+
+  abstract class SlickStreamingResultFunction[I, R, F[_]: Async](functionNameOverride: Option[String] = None)(implicit
+    override val schema: DBSchema,
+    dBEngine: SlickPgStreamingEngine[F]
+  ) extends DBStreamingResultFunction[I, R, SlickPgStreamingEngine[F], F](functionNameOverride)
       with SlickFunction[I, R]
 
   /**

--- a/slick/src/main/scala/za/co/absa/fadb/slick/SlickPgEngine.scala
+++ b/slick/src/main/scala/za/co/absa/fadb/slick/SlickPgEngine.scala
@@ -49,6 +49,11 @@ class SlickPgEngine(val db: Database)(implicit val executor: ExecutionContext) e
     db.run(slickAction)
   }
 
+//  protected def runStreaming[R](query: QueryType[R]): fs2.Stream[Future, R] = {
+//    val slickPublisher = db.stream(query.sql.as[R](query.getResult))
+//    slickPublisher.toStreamBuffered[Future](100) // parameter for buffer size
+//  }
+
   /**
    *  Execution using Slick with status
    *  @param query  - the Slick query to execute

--- a/slick/src/main/scala/za/co/absa/fadb/slick/SlickPgStreamingEngine.scala
+++ b/slick/src/main/scala/za/co/absa/fadb/slick/SlickPgStreamingEngine.scala
@@ -1,0 +1,17 @@
+package za.co.absa.fadb.slick
+
+import cats.effect.Async
+import fs2.interop.reactivestreams.PublisherOps
+import slick.jdbc.JdbcBackend.Database
+import za.co.absa.fadb.DBStreamingEngine
+
+class SlickPgStreamingEngine[F[_]: Async](val db: Database, chunkSize: Int = 512) extends DBStreamingEngine[F] {
+
+  type QueryType[R] = SlickQuery[R]
+
+  def runStreaming[R](query: QueryType[R]): fs2.Stream[F, R] = {
+    val slickPublisher = db.stream(query.sql.as[R](query.getResult))
+    slickPublisher.toStreamBuffered[F](chunkSize)
+  }
+
+}


### PR DESCRIPTION
Added support for streaming for both Slick and Doobie module. Since Slick works with Futures but for streaming it relies on IOs or other effect types there was a need to abstract the streaming operation in a new DBStreamingEngine. 

Closes #107 