### PR TITLE
Apply release version of filename-inspector

### DIFF
--- a/.github/workflows/test_filenames_check.yml
+++ b/.github/workflows/test_filenames_check.yml
@@ -36,6 +36,11 @@ jobs:
           name-patterns: '*UnitTests.*,*IntegrationTests.*'
           paths: '**/src/test/scala/**'
           report-format: 'console'
-#          excludes: '**/src/test/scala/za/co/absa/db/fadb/testing/**'
+          excludes: |
+            slick/src/test/scala/za/co/absa/db/fadb/testing/classes/OptionalActorSlickConverter.scala,
+            slick/src/test/scala/za/co/absa/db/fadb/testing/classes/ActorSlickConverter.scala,
+            slick/src/test/scala/za/co/absa/db/fadb/testing/classes/Actor.scala,
+            slick/src/test/scala/za/co/absa/db/fadb/testing/classes/SlickTest.scala,
+            doobie/src/test/scala/za/co/absa/db/fadb/testing/classes/DoobieTest.scala
           verbose-logging: 'true'
           fail-on-violation: 'true'

--- a/.github/workflows/test_filenames_check.yml
+++ b/.github/workflows/test_filenames_check.yml
@@ -42,5 +42,5 @@ jobs:
             slick/src/test/scala/za/co/absa/db/fadb/testing/classes/Actor.scala,
             slick/src/test/scala/za/co/absa/db/fadb/testing/classes/SlickTest.scala,
             doobie/src/test/scala/za/co/absa/db/fadb/testing/classes/DoobieTest.scala
-          verbose-logging: 'true'
+          verbose-logging: 'false'
           fail-on-violation: 'true'

--- a/.github/workflows/test_filenames_check.yml
+++ b/.github/workflows/test_filenames_check.yml
@@ -31,11 +31,11 @@ jobs:
 
       - name: Filename Inspector
         id: scan-test-files
-        uses: AbsaOSS/filename-inspector@master
+        uses: AbsaOSS/filename-inspector@v0.1.0
         with:
           name-patterns: '*UnitTests.*,*IntegrationTests.*'
           paths: '**/src/test/scala/**'
           report-format: 'console'
-          excludes: '**/src/test/scala/za/co/absa/db/fadb/testing/**'
-          verbose-logging: 'false'
+#          excludes: '**/src/test/scala/za/co/absa/db/fadb/testing/**'
+          verbose-logging: 'true'
           fail-on-violation: 'true'


### PR DESCRIPTION
- Used released version of filename-inspector.
- Prepared for debug of better exclusion of non *Test files.

Closes #136 