### PR TITLE
addressed CVE-2022-31183 by patching fs2

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -51,7 +51,10 @@ lazy val commonSettings = Seq(
   scalacOptions ++= commonScalacOptions,
   Test / parallelExecution := false,
   (Compile / compile) := ((Compile / compile) dependsOn printScalaVersion).value, // printScalaVersion is run with compile
-  jacocoExcludes := commonJacocoExcludes
+  jacocoExcludes := commonJacocoExcludes,
+  // to mitigate CVE-2022-31183
+  dependencyOverrides += "co.fs2" %% "fs2-core" % "3.2.11",
+  dependencyOverrides += "co.fs2" %% "fs2-io"   % "3.2.11",
 )
 
 lazy val parent = (project in file("."))

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -41,3 +41,5 @@ addSbtPlugin("za.co.absa.sbt" % "sbt-jacoco" % "3.4.1-absa.4" from "https://gith
 addSbtPlugin("com.thoughtworks.sbt-api-mappings" % "sbt-api-mappings" % "3.0.2")
 
 addSbtPlugin("io.github.davidmweber" % "flyway-sbt" % "7.4.0")
+
+addDependencyTreePlugin


### PR DESCRIPTION
addressed CVE-2022-31183 by patching fs2

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Mitigated CVE-2022-31183 security vulnerability by pinning library versions to address transitive dependency issues.

* **Chores**
  * Added dependency tree visualization capability to the build system for improved dependency management.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->